### PR TITLE
Share git providers across projects via BuildService

### DIFF
--- a/blueprint-core/api/blueprint-core.api
+++ b/blueprint-core/api/blueprint-core.api
@@ -9,9 +9,9 @@ public final class blueprint/core/DependenciesKt {
 }
 
 public final class blueprint/core/GitKt {
-	public static final fun gitVersionCode (Lorg/gradle/api/provider/ProviderFactory;)Lorg/gradle/api/provider/Provider;
-	public static final fun gitVersionDate (Lorg/gradle/api/provider/ProviderFactory;)Lorg/gradle/api/provider/Provider;
-	public static final fun gitVersionHash (Lorg/gradle/api/provider/ProviderFactory;)Lorg/gradle/api/provider/Provider;
+	public static final fun gitVersionCode (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun gitVersionDate (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
+	public static final fun gitVersionHash (Lorg/gradle/api/Project;)Lorg/gradle/api/provider/Provider;
 }
 
 public final class blueprint/core/JavaVersionKt {

--- a/blueprint-core/src/main/kotlin/blueprint/core/Git.kt
+++ b/blueprint-core/src/main/kotlin/blueprint/core/Git.kt
@@ -1,42 +1,83 @@
 package blueprint.core
 
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.process.ExecOperations
 import java.io.ByteArrayOutputStream
 import java.time.Instant
 import java.time.ZoneOffset
 import java.util.Locale
 import javax.inject.Inject
-import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
-import org.gradle.api.provider.ValueSource
-import org.gradle.api.provider.ValueSourceParameters
-import org.gradle.process.ExecOperations
 
-public fun ProviderFactory.gitVersionHash(): Provider<String> =
-  of(GitVersionHashValueSource::class.java) {}
+public fun Project.gitVersionHash(): Provider<String> =
+  GitInfoService.registerOrGet(this).versionHash
 
-public fun ProviderFactory.gitVersionCode(): Provider<Int> =
-  of(GitVersionCodeValueSource::class.java) {}
+public fun Project.gitVersionCode(): Provider<Int> = GitInfoService.registerOrGet(this).versionCode
 
-public fun ProviderFactory.gitVersionDate(): Provider<String> =
-  gitVersionCode().map { seconds ->
-    val date = Instant.ofEpochSecond(seconds.toLong()).atZone(ZoneOffset.UTC).toLocalDate()
-    "%04d.%02d.%02d".format(Locale.getDefault(), date.year, date.monthValue, date.dayOfMonth)
+public fun Project.gitVersionDate(): Provider<String> = gitVersionCode().toVersionDate()
+
+private fun Provider<Int>.toVersionDate(): Provider<String> = map { seconds ->
+  val date = Instant.ofEpochSecond(seconds.toLong()).atZone(ZoneOffset.UTC).toLocalDate()
+  "%04d.%02d.%02d".format(Locale.getDefault(), date.year, date.monthValue, date.dayOfMonth)
+}
+
+internal abstract class GitInfoService : BuildService<GitInfoService.Parameters> {
+  interface Parameters : BuildServiceParameters {
+    val versionHash: Property<String>
+    val versionCode: Property<Int>
   }
 
-private abstract class GitVersionHashValueSource : ValueSource<String, ValueSourceParameters.None> {
+  val versionHash: Provider<String>
+    get() = parameters.versionHash
+
+  val versionCode: Provider<Int>
+    get() = parameters.versionCode
+
+  companion object {
+    fun registerOrGet(project: Project): GitInfoService =
+      project.gradle.sharedServices
+        .registerIfAbsent("gitInfoService", GitInfoService::class.java) { spec ->
+          val workingDir = project.layout.projectDirectory
+          spec.parameters.versionHash.set(
+            project.providers.of(GitVersionHashValueSource::class.java) { source ->
+              source.parameters.workingDir.set(workingDir)
+            }
+          )
+          spec.parameters.versionCode.set(
+            project.providers.of(GitVersionCodeValueSource::class.java) { source ->
+              source.parameters.workingDir.set(workingDir)
+            }
+          )
+        }
+        .get()
+  }
+}
+
+private interface GitValueSourceParameters : ValueSourceParameters {
+  val workingDir: DirectoryProperty
+}
+
+private abstract class GitVersionHashValueSource : ValueSource<String, GitValueSourceParameters> {
   @get:Inject abstract val execOperations: ExecOperations
 
   override fun obtain(): String =
     ByteArrayOutputStream().use { baos ->
       execOperations.exec { spec ->
-        spec.commandLine("git", "rev-parse", "--short=8", "HEAD")
+        spec.commandLine("git", "rev-parse", "HEAD")
         spec.standardOutput = baos
+        spec.workingDir = parameters.workingDir.get().asFile
       }
       baos.toString().trim()
     }
 }
 
-private abstract class GitVersionCodeValueSource : ValueSource<Int, ValueSourceParameters.None> {
+private abstract class GitVersionCodeValueSource : ValueSource<Int, GitValueSourceParameters> {
   @get:Inject abstract val execOperations: ExecOperations
 
   override fun obtain(): Int {
@@ -45,6 +86,7 @@ private abstract class GitVersionCodeValueSource : ValueSource<Int, ValueSourceP
         execOperations.exec { spec ->
           spec.commandLine("git", "show", "-s", "--format=%ct")
           spec.standardOutput = baos
+          spec.workingDir = parameters.workingDir.get().asFile
         }
         baos.toString().trim()
       }

--- a/blueprint-core/src/main/kotlin/blueprint/core/Git.kt
+++ b/blueprint-core/src/main/kotlin/blueprint/core/Git.kt
@@ -1,5 +1,10 @@
 package blueprint.core
 
+import java.io.ByteArrayOutputStream
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Locale
+import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
@@ -9,11 +14,6 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.process.ExecOperations
-import java.io.ByteArrayOutputStream
-import java.time.Instant
-import java.time.ZoneOffset
-import java.util.Locale
-import javax.inject.Inject
 
 public fun Project.gitVersionHash(): Provider<String> =
   GitInfoService.registerOrGet(this).versionHash

--- a/blueprint-core/src/test/kotlin/blueprint/core/GitScenario.kt
+++ b/blueprint-core/src/test/kotlin/blueprint/core/GitScenario.kt
@@ -1,0 +1,85 @@
+package blueprint.core
+
+import blueprint.test.DEFAULT_REPOSITORIES_KTS
+import blueprint.test.GRADLE_VERSION
+import blueprint.test.Scenario
+import blueprint.test.ScenarioTest
+import blueprint.test.assertThatTask
+import blueprint.test.buildsSuccessfully
+import blueprint.test.outputContainsLine
+import blueprint.test.outputContainsMatch
+import kotlin.test.Test
+
+class GitScenario : ScenarioTest() {
+  override val gradleVersion = GRADLE_VERSION
+
+  override val fileTree = fileTree {
+    "settings.gradle.kts"(
+      DEFAULT_REPOSITORIES_KTS +
+        """
+        include(":a", ":b")
+        """
+          .trimIndent()
+    )
+
+    val buildScript =
+      $$"""
+      import blueprint.core.*
+
+      plugins { id("dev.jonpoulton.blueprint") }
+
+      fun <T : Any> registerTask(name: String, property: Provider<T>) = tasks.register(name) {
+        inputs.property("property", property)
+        inputs.property("name", name)
+        doLast { logger.lifecycle("$name = ${property.get()}") }
+      }
+
+      // Project-receiver overloads share a single provider instance across the whole build.
+      registerTask("printHash", gitVersionHash())
+      registerTask("printCode", gitVersionCode())
+      registerTask("printDate", gitVersionDate())
+      """
+        .trimIndent()
+
+    "a" { "build.gradle.kts"(buildScript) }
+    "b" { "build.gradle.kts"(buildScript) }
+  }
+
+  @Test
+  fun `Shared git providers resolve consistently across projects`() = runScenario {
+    val hash = initGitRepo()
+
+    assertThatTask(
+        ":a:printHash",
+        ":b:printHash",
+        ":a:printCode",
+        ":b:printCode",
+        ":a:printDate",
+        ":b:printDate",
+      )
+      .buildsSuccessfully()
+      .outputContainsLine("printHash = $hash")
+      .outputContainsMatch("""printCode = \d+""".toRegex())
+      .outputContainsMatch("""printDate = \d{4}\.\d{2}\.\d{2}""".toRegex())
+  }
+
+  /** Initialises a git repo in [Scenario.rootDir] with a single commit and returns its commit hash. */
+  private fun Scenario.initGitRepo(): String {
+    git("init", "--initial-branch=main")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    rootDir.resolve(".gitignore").writeText("")
+    git("add", ".gitignore")
+    git("commit", "--no-gpg-sign", "-m", "Initial commit")
+    return git("rev-parse", "HEAD").trim()
+  }
+
+  private fun Scenario.git(vararg args: String): String {
+    val process =
+      ProcessBuilder(listOf("git") + args).directory(rootDir).redirectErrorStream(true).start()
+    val output = process.inputStream.bufferedReader().use { it.readText() }
+    val exit = process.waitFor()
+    check(exit == 0) { "git ${args.joinToString(" ")} failed ($exit):\n$output" }
+    return output
+  }
+}

--- a/blueprint-core/src/test/kotlin/blueprint/core/GitScenario.kt
+++ b/blueprint-core/src/test/kotlin/blueprint/core/GitScenario.kt
@@ -63,7 +63,6 @@ class GitScenario : ScenarioTest() {
       .outputContainsMatch("""printDate = \d{4}\.\d{2}\.\d{2}""".toRegex())
   }
 
-  /** Initialises a git repo in [Scenario.rootDir] with a single commit and returns its commit hash. */
   private fun Scenario.initGitRepo(): String {
     git("init", "--initial-branch=main")
     git("config", "user.email", "test@example.com")

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ SONATYPE_AUTOMATIC_RELEASE=true
 RELEASE_SIGNING_ENABLED=true
 
 GROUP=dev.jonpoulton.blueprint
-VERSION_NAME=2.2.0
+VERSION_NAME=2.3.0
 
 POM_INCEPTION_YEAR=2024
 POM_URL=https://github.com/jonapoul/blueprint


### PR DESCRIPTION
## Summary

The git version providers in `Git.kt` previously used a `ValueSource` per provider instance. As described in [Aurimas Liutikas's "Hidden Fingerprinting"](https://www.liutikas.net/2026/06/25/Hidden-Fingerprinting.html), Gradle runs `ValueSource.obtain()` during the input-fingerprinting step on **every** invocation — even on a configuration-cache hit — once per provider instance. In a multi-project build that means one `git` invocation per project, serially, creating real I/O pressure (AndroidX measured a 24x speedup from sharing: 3.45s → 0.14s).

This PR backs the providers with a shared `GitInfoService` build service, so the underlying `git` command runs **once per build** regardless of how many projects consume it.

## Changes

- **New `GitInfoService` `BuildService`** holds the single shared provider, registered build-wide via `registerIfAbsent`.
- **Public API moves from `ProviderFactory` to `Project` receivers** — `Project.gitVersionHash()`, `gitVersionCode()`, `gitVersionDate()`. ABI reference updated accordingly. ⚠️ **Breaking change** for callers using the `providers.gitVersion*()` form.
- **Value sources gain a `workingDir` parameter** bound to the project directory, removing the implicit reliance on the Gradle process working directory.
- **New `GitScenario` test** verifies the shared providers resolve consistently across multiple projects (`:a`, `:b`).
- **Version bump** `2.2.0` → `2.3.0`.

## Test plan

- `./gradlew check` passes (tests + detekt + ABI validation).