### PR TITLE
Add square/gradle-dependencies-sorter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,7 @@ jobs:
       shell: ${{ steps.filter.outputs.shell }}
       kotlin: ${{ steps.filter.outputs.kotlin }}
       workflows: ${{ steps.filter.outputs.workflows }}
+      sortDependencies: ${{ steps.filter.outputs.sortDependencies }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
@@ -53,6 +54,9 @@ jobs:
             workflows:
               - '.github/workflows/**'
               - '.github/actions/**'
+            sortDependencies:
+              - '**/*.kts'
+              - 'build-logic/**'
 
   renovate:
     needs: changed-files
@@ -172,6 +176,17 @@ jobs:
       - uses: gmazzo/publish-report-annotations@d9c7375f4c587879eeedba56c6e35f1235219f9f # v1
         if: ${{ !cancelled() }}
 
+  sort-dependencies:
+    needs: [ changed-files, validation ]
+    if: ${{ !cancelled() && needs.validation.result == 'success' && needs.changed-files.outputs.sortDependencies == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-gradle
+      - run: ./gradlew checkSortDependencies
+
   dependency-guard:
     needs: validation
     if: ${{ !cancelled() && needs.validation.result == 'success' && !startsWith(github.head_ref, 'renovate/') }}
@@ -219,6 +234,7 @@ jobs:
       - check-build-logic
       - detekt
       - tests
+      - sort-dependencies
       - dependency-guard
       - dependency-guard-baseline
     runs-on: ubuntu-latest

--- a/.run/sortDependencies.run.xml
+++ b/.run/sortDependencies.run.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="sortDependencies" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="sortDependencies" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/blueprint-core/build.gradle.kts
+++ b/blueprint-core/build.gradle.kts
@@ -8,15 +8,14 @@ plugins {
 dependencies {
   compileOnly(gradleApi())
   compileOnly(kotlin("gradle-plugin"))
-
-  testCompileOnly(libs.junit.api)
+  testImplementation(project(":blueprint-test-assertk"))
+  testImplementation(project(":blueprint-test-runtime"))
   testImplementation(kotlin("stdlib"))
   testImplementation(kotlin("test"))
   testImplementation(libs.assertk)
-  testImplementation(project(":blueprint-test-assertk"))
-  testImplementation(project(":blueprint-test-runtime"))
-  testPluginClasspath(kotlin("gradle-plugin"))
+  testCompileOnly(libs.junit.api)
   testRuntimeOnly(libs.junit.launcher)
+  testPluginClasspath(kotlin("gradle-plugin"))
 }
 
 gradlePlugin {

--- a/blueprint-test-assertk/build.gradle.kts
+++ b/blueprint-test-assertk/build.gradle.kts
@@ -1,12 +1,11 @@
 plugins { id("blueprint.convention") }
 
 dependencies {
-  api(libs.assertk)
   api(project(":blueprint-test-runtime"))
+  api(libs.assertk)
   compileOnly(gradleTestKit())
-
-  testCompileOnly(libs.junit.api)
   testImplementation(kotlin("stdlib"))
   testImplementation(kotlin("test"))
+  testCompileOnly(libs.junit.api)
   testRuntimeOnly(libs.junit.launcher)
 }

--- a/blueprint-test-plugin/build.gradle.kts
+++ b/blueprint-test-plugin/build.gradle.kts
@@ -7,10 +7,9 @@ plugins {
 
 dependencies {
   compileOnly(gradleApi())
-
-  testCompileOnly(libs.junit.api)
   testImplementation(kotlin("stdlib"))
   testImplementation(kotlin("test"))
+  testCompileOnly(libs.junit.api)
   testRuntimeOnly(libs.junit.launcher)
 }
 

--- a/blueprint-test-runtime/build.gradle.kts
+++ b/blueprint-test-runtime/build.gradle.kts
@@ -3,9 +3,8 @@ plugins { id("blueprint.convention") }
 dependencies {
   api(libs.junit.api)
   compileOnly(gradleTestKit())
-
-  testCompileOnly(libs.junit.api)
   testImplementation(kotlin("stdlib"))
   testImplementation(kotlin("test"))
+  testCompileOnly(libs.junit.api)
   testRuntimeOnly(libs.junit.launcher)
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
   compileOnlyPlugin(libs.plugins.dokka)
   compileOnlyPlugin(libs.plugins.kotlin)
   compileOnlyPlugin(libs.plugins.publish)
+  compileOnlyPlugin(libs.plugins.sortDependencies)
 }
 
 gradlePlugin {

--- a/build-logic/src/main/kotlin/blueprint/gradle/Convention.kt
+++ b/build-logic/src/main/kotlin/blueprint/gradle/Convention.kt
@@ -7,6 +7,8 @@ import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPlugin
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPluginExtension
 import com.github.gmazzo.buildconfig.BuildConfigExtension
 import com.github.gmazzo.buildconfig.BuildConfigPlugin
+import com.squareup.sort.SortDependenciesExtension
+import com.squareup.sort.SortDependenciesPlugin
 import com.vanniktech.maven.publish.MavenPublishPlugin
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.extensions.DetektExtension
@@ -23,7 +25,6 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.buildConfigField
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.withType
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.plugin.devel.tasks.PluginUnderTestMetadata
@@ -46,12 +47,14 @@ class Convention : Plugin<Project> {
         apply(DependencyAnalysisPlugin::class)
         apply(BuildConfigPlugin::class)
         apply(DependencyGuardPlugin::class)
+        apply(SortDependenciesPlugin::class)
       }
 
       kotlin()
       test()
       detekt()
       dependencyGuard()
+      sortDependencies()
     }
 
   private fun Project.kotlin() {
@@ -145,6 +148,13 @@ class Convention : Plugin<Project> {
     extensions.configure(DependencyGuardPluginExtension::class) {
       configuration("compileClasspath")
       configuration("runtimeClasspath")
+    }
+  }
+
+  private fun Project.sortDependencies() {
+    extensions.configure(SortDependenciesExtension::class) {
+      insertBlankLines.set(false)
+      check(true)
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   alias(libs.plugins.dokka) apply false
   alias(libs.plugins.kotlin) apply false
   alias(libs.plugins.publish) apply false
+  alias(libs.plugins.sortDependencies) apply false
 
   alias(libs.plugins.dependencyAnalysis)
   alias(libs.plugins.dependencyGuard)

--- a/dependencies/classpath.txt
+++ b/dependencies/classpath.txt
@@ -34,9 +34,11 @@ com.squareup.okio:okio:3.15.0
 com.squareup.retrofit2:converter-moshi:3.0.0
 com.squareup.retrofit2:converter-scalars:3.0.0
 com.squareup.retrofit2:retrofit:3.0.0
+com.squareup.sort-dependencies:com.squareup.sort-dependencies.gradle.plugin:0.20.0
 com.squareup:javapoet:1.13.0
 com.squareup:kotlinpoet-jvm:2.2.0
 com.squareup:kotlinpoet:2.2.0
+com.squareup:sort-dependencies-gradle-plugin:0.20.0
 com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.37.0
 com.vanniktech:central-portal:0.37.0
 com.vanniktech:gradle-maven-publish-plugin:0.37.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,3 +21,4 @@ detekt = { id = "dev.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version = "2.4.10" }
 publish = { id = "com.vanniktech.maven.publish", version = "0.37.0" }
+sortDependencies = { id = "com.squareup.sort-dependencies", version = "0.20.0" }


### PR DESCRIPTION
## Summary
- Apply the `com.squareup.sort-dependencies` plugin (0.20.0) to every subproject via the `blueprint.convention` plugin, wiring `checkSortDependencies` into `check`
- Add a `sort-dependencies` CI job that runs `checkSortDependencies`, gated on `.kts` files or `build-logic/**` having changed
- Sort the existing `dependencies {}` blocks to match the tool's canonical ordering

## Test plan
- [x] `./gradlew check` passes locally
- [x] `./gradlew checkSortDependencies` passes for all subprojects