### PR TITLE
Apply gradle-report-publications-plugin v1.4.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ pluginManagement { includeBuild("build-logic") }
 plugins {
   id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
   id("com.gradle.develocity") version "4.5.0"
+  id("io.github.gmazzo.publications.report") version "1.4.0"
 }
 
 develocity { buildScan.publishing.onlyIf { false } }


### PR DESCRIPTION
Applies https://github.com/gmazzo/gradle-report-publications-plugin in settings.gradle.kts (isolated projects requires it there). Prints Maven coordinates of published artifacts in the build log.

Verified with `./gradlew publishToMavenLocal`, which now prints the artifact GAV coordinates for all published modules.